### PR TITLE
Added missingok flag in the config.

### DIFF
--- a/logrotate.conf
+++ b/logrotate.conf
@@ -1,8 +1,9 @@
 /var/lib/docker/containers/*/*.log {
+  missingok
   rotate 0
   copytruncate
   sharedscripts
-  maxsize 10M
+  size 10M
   postrotate
     rm -f /var/lib/docker/containers/*/*.log.*
   endscript


### PR DESCRIPTION
Changed maxsize to size
Changed maxsize to size as we can see that maxsize was not having an
effect on log rotation and we were getting logs above 100M per container
before any rotation can actually hit. I have seen through the manual and
can find that maxsize attribute has been added in later version of
logrotate. The logrotate version this has been tested against it 3.8.8
