### PR TITLE
Truncate all container logs once logrotate container is up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 MAINTAINER support@tutum.co
 
 RUN apk --update add logrotate
-RUN echo "*/5 *	* * *	/usr/sbin/logrotate /etc/logrotate.conf" >> /etc/crontabs/root
+RUN echo "*/30 *	* * *	/usr/sbin/logrotate /etc/logrotate.conf" >> /etc/crontabs/root
 ADD logrotate.conf /etc/logrotate.conf
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,7 @@ RUN apk --update add logrotate
 RUN echo "*/5 *	* * *	/usr/sbin/logrotate /etc/logrotate.conf" >> /etc/crontabs/root
 ADD logrotate.conf /etc/logrotate.conf
 
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
 CMD ["crond", "-f"]

--- a/README.md
+++ b/README.md
@@ -3,5 +3,12 @@ Truncates container logs when they grow in size
 
 ## Usage
 
-	docker run -d -v /var/lib/docker/containers:/var/lib/docker/containers:rw tutum/logrotate
+``` bash
+docker run -d -v /var/lib/docker/containers:/var/lib/docker/containers:rw dailyhotel/logrotate
+```
 
+Sometimes very large log files are already occupying the most of storages and no place to copy the original log files onto is left on the disk. For such a case, you can set `UP_AND_RUN` environment variable to truncate the container logs immediately:
+
+``` bash
+docker run -d -e UP_AND_RUN=true -v /var/lib/docker/containers:/var/lib/docker/containers:rw dailyhotel/logrotate
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${UP_AND_RUN}" = "true" ]; then
   truncate -s 0 /var/lib/docker/containers/*/*.log
 fi
 
+if [ -n "${BASE64_ENCODED_LOGROTATE_CONF}" ]; then
+  echo "${BASE64_ENCODED_LOGROTATE_CONF}" | base64 -d > /etc/logrotate.conf
+fi
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${UP_AND_RUN}" = "true" ]; then
+  truncate -s 0 /var/lib/docker/containers/*/*.log
+fi
+
+exec "$@"

--- a/logrotate.conf
+++ b/logrotate.conf
@@ -2,7 +2,7 @@
   rotate 0
   copytruncate
   sharedscripts
-  maxsize 10M
+  maxsize 2048M
   postrotate
     rm -f /var/lib/docker/containers/*/*.log.*
   endscript


### PR DESCRIPTION
Sometimes very large log files are already occupying the most of storages and no place to copy the original log files is left on the disk. For such a case, you can set `UP_AND_RUN` environment variable to truncate the container logs immediately.